### PR TITLE
Change error message to be more ActiveRecord-like

### DIFF
--- a/lib/static_data_model.rb
+++ b/lib/static_data_model.rb
@@ -62,7 +62,7 @@ module StaticDataModel
     def find(id)
       all.find { |instance| instance.id == id } ||
         raise(error_namespace::RecordNotFound,
-              "Couldn't find #{self} with ID #{id}")
+              "Couldn't find #{self} with 'id'=#{id}")
     end
 
     attr_reader :attribute_names

--- a/spec/lib/static_data_model_spec.rb
+++ b/spec/lib/static_data_model_spec.rb
@@ -59,14 +59,14 @@ RSpec.describe StaticDataModel do
 
         it 'raises ActiveRecord::RecordNotFound' do
           expect { dummy_class.find(4) }
-            .to raise_error(ActiveRecord::RecordNotFound, /with ID 4/)
+            .to raise_error(ActiveRecord::RecordNotFound, /with 'id'=4/)
         end
       end
 
       context 'and raises_activerecord_errors has never been called' do
         it 'raises StaticDataModel::Errors::RecordNotFound' do
           expect { dummy_class.find(4) }
-            .to raise_error(Errors::RecordNotFound, /with ID 4/)
+            .to raise_error(Errors::RecordNotFound, /with 'id'=4/)
         end
       end
     end


### PR DESCRIPTION
This is important for the API V3 to return the ID on
error messages as well.